### PR TITLE
Android NDK9e / Android 4.3 fixes and added Logcat output :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Android NDK
 = build the hijack tool =
 ```
 cd hijack
-cd jni
 ndk-build
 cd ..
 adb push libs/armeabi/hijack /data/local/tmp/
@@ -54,7 +53,6 @@ cd ..
 
 ```
 cd example
-cd jni
 ndk-build
 cd ..
 adb push libs/armeabi/libexample.so /data/local/tmp/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Android NDK
 ```
 cd hijack
 ndk-build
-cd ..
 adb push libs/armeabi/hijack /data/local/tmp/
 adb shell chmod 755 /data/local/tmp/hijack
 cd ..
@@ -54,7 +53,6 @@ cd ..
 ```
 cd example
 ndk-build
-cd ..
 adb push libs/armeabi/libexample.so /data/local/tmp/
 adb shell chmod 755 /data/local/tmp/libexample.so
 ```
@@ -67,7 +65,8 @@ su
 cd /data/local/tmp
 # GET PID from com.android.phone
 ./hijack -d -p PID -l /data/local/tmp/libexample.so
-cat adbi_example.log
+exit
+adb logcat (see log entries hook-epoll)
 ```
 
 output should look similar to:

--- a/README.md
+++ b/README.md
@@ -45,18 +45,8 @@ cd hijack
 cd jni
 ndk-build
 cd ..
-adb push libs/armeabi/hijack 
-cd ..
-```
-
-= build the instrumentation base code =
-
-```
-cd instruments
-cd base
-cd jni
-ndk-build
-cd ..
+adb push libs/armeabi/hijack /data/local/tmp/
+adb shell chmod 755 /data/local/tmp/hijack
 cd ..
 ```
 
@@ -68,6 +58,7 @@ cd jni
 ndk-build
 cd ..
 adb push libs/armeabi/libexample.so /data/local/tmp/
+adb shell chmod 755 /data/local/tmp/libexample.so
 ```
 
 === How to Run ===

--- a/instruments/base/hook.c
+++ b/instruments/base/hook.c
@@ -48,11 +48,11 @@ int hook_direct(struct hook_t *h, unsigned int addr, void *hookf)
 {
 	int i;
 	
-	log("addr  = %x\n", addr)
-	log("hookf = %x\n", hookf)
+	log("addr  = %x\n", (unsigned int)addr)
+	log("hookf = %x\n", (unsigned int)hookf)
 
 	if ((addr % 4 == 0 && (unsigned int)hookf % 4 != 0) || (addr % 4 != 0 && (unsigned int)hookf % 4 == 0))
-		log("addr 0x%x and hook 0x%x\n don't match!\n", addr, hookf)
+		log("addr 0x%x and hook 0x%x\n don't match!\n", (unsigned int)addr, (unsigned int)hookf)
 	
 	//log("ARM\n")
 	h->thumb = 0;
@@ -81,11 +81,11 @@ int hook(struct hook_t *h, int pid, char *libname, char *funcname, void *hook_ar
 		return 0;
 	}
 	
-	log("hooking:   %s = 0x%x ", funcname, addr)
+	log("hooking:   %s = 0x%x ", funcname, (unsigned int)addr)
 	strncpy(h->name, funcname, sizeof(h->name)-1);
 
 	if (addr % 4 == 0) {
-		log("ARM using 0x%x\n", hook_arm)
+		log("ARM using 0x%x\n", (unsigned int)hook_arm)
 		h->thumb = 0;
 		h->patch = (unsigned int)hook_arm;
 		h->orig = addr;
@@ -99,9 +99,9 @@ int hook(struct hook_t *h, int pid, char *libname, char *funcname, void *hook_ar
 	}
 	else {
 		if ((unsigned long int)hook_thumb % 4 == 0)
-			log("warning hook is not thumb 0x%x\n", hook_thumb)
+			log("warning hook is not thumb 0x%x\n", (unsigned int)hook_thumb)
 		h->thumb = 1;
-		log("THUMB using 0x%x\n", hook_thumb)
+		log("THUMB using 0x%x\n", (unsigned int)hook_thumb)
 		h->patch = (unsigned int)hook_thumb;
 		h->orig = addr;	
 		h->jumpt[1] = 0xb4;

--- a/instruments/example/epoll.c
+++ b/instruments/example/epoll.c
@@ -33,8 +33,8 @@
 #undef log
 #include <android/log.h>
 
-#define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO, "hook-ioctl", __VA_ARGS__))
-#define LOGE(...) ((void)__android_log_print(ANDROID_LOG_ERROR, "hook-ioctl", __VA_ARGS__)) 
+#define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO, "hook-epoll", __VA_ARGS__))
+#define LOGE(...) ((void)__android_log_print(ANDROID_LOG_ERROR, "hook-epoll", __VA_ARGS__)) 
 #define log(...) \
         {FILE *fp = fopen("/data/local/tmp/adbi_example.log", "a+");\
         fprintf(fp, __VA_ARGS__);\

--- a/instruments/example/epoll.c
+++ b/instruments/example/epoll.c
@@ -60,7 +60,7 @@ extern int my_epoll_wait_arm(int epfd, struct epoll_event *events, int maxevents
  */
 static void my_log(char *msg)
 {
-	LOGI(msg)
+	LOGI("%s",msg);
 }
 
 int my_epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeout)
@@ -85,7 +85,7 @@ void my_init(void)
 {
 	counter = 3;
 
-	LOGI("%s started\n", __FILE__)
+	LOGI("%s started\n", __FILE__);
  
 	set_logfunction(my_log);
 

--- a/instruments/example/epoll.c
+++ b/instruments/example/epoll.c
@@ -8,6 +8,7 @@
  *  License: LGPL v2.1
  *
  */
+// Modified by B.Kerler to support Android Logcat + NDK9
 
 #define _GNU_SOURCE
 #include <stdio.h>
@@ -30,7 +31,10 @@
 #include "../base/base.h"
 
 #undef log
+#include <android/log.h>
 
+#define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO, "hook-ioctl", __VA_ARGS__))
+#define LOGE(...) ((void)__android_log_print(ANDROID_LOG_ERROR, "hook-ioctl", __VA_ARGS__)) 
 #define log(...) \
         {FILE *fp = fopen("/data/local/tmp/adbi_example.log", "a+");\
         fprintf(fp, __VA_ARGS__);\
@@ -56,7 +60,7 @@ extern int my_epoll_wait_arm(int epfd, struct epoll_event *events, int maxevents
  */
 static void my_log(char *msg)
 {
-	log(msg)
+	LOGI(msg)
 }
 
 int my_epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeout)
@@ -68,10 +72,10 @@ int my_epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeo
 	int res = orig_epoll_wait(epfd, events, maxevents, timeout);
 	if (counter) {
 		hook_postcall(&eph);
-		log("epoll_wait() called\n");
+		LOGI("epoll_wait() called\n");
 		counter--;
 		if (!counter)
-			log("removing hook for epoll_wait()\n");
+			LOGI("removing hook for epoll_wait()\n");
 	}
         
 	return res;
@@ -81,7 +85,7 @@ void my_init(void)
 {
 	counter = 3;
 
-	log("%s started\n", __FILE__)
+	LOGI("%s started\n", __FILE__)
  
 	set_logfunction(my_log);
 

--- a/instruments/example/epoll_arm.c
+++ b/instruments/example/epoll_arm.c
@@ -11,6 +11,7 @@
 
 #include <sys/types.h>
 #include <sys/epoll.h>
+#include <android/log.h>
 
 extern int my_epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeout);
 

--- a/instruments/example/jni/Android.mk
+++ b/instruments/example/jni/Android.mk
@@ -19,7 +19,6 @@ include $(CLEAR_VARS)
 LOCAL_MODULE    := libexample
 LOCAL_SRC_FILES := ../epoll.c  ../epoll_arm.c.arm ../../base/util.c ../../base/hook.c ../../base/base.c 
 LOCAL_LDLIBS    := -L./libs -ldl -llog
-LOCAL_LDLIBS := -Wl,--start-group ../../base/obj/local/armeabi/libbase.a  -Wl,--end-group
 LOCAL_CFLAGS := -g
 
 include $(BUILD_SHARED_LIBRARY)

--- a/instruments/example/jni/Android.mk
+++ b/instruments/example/jni/Android.mk
@@ -17,8 +17,8 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE    := libexample
-LOCAL_SRC_FILES := ../epoll.c  ../epoll_arm.c.arm
-LOCAL_LDLIBS    := -L./libs -ldl -ldvm -lbase
+LOCAL_SRC_FILES := ../epoll.c  ../epoll_arm.c.arm ../../base/util.c ../../base/hook.c ../../base/base.c 
+LOCAL_LDLIBS    := -L./libs -ldl -llog
 LOCAL_LDLIBS := -Wl,--start-group ../../base/obj/local/armeabi/libbase.a  -Wl,--end-group
 LOCAL_CFLAGS := -g
 


### PR DESCRIPTION
Hi,

I've fixed some compiling issues with Android NDK9e, made the build process easier and fixed the README. I've added logging to LOGCAT for the example instead of logging to a file.

Verified and working with Samsung Galaxy GT-I9300 with latest 4.3 firmware with SELinux Kernel and MobiCore code injection using Android NDK9e. The hook cleanup still needs to be fixed as it seems to crash the process after freeing the hook.

Kind regards and thanks for your great code,
Bjoern Kerler (info@revskills.de)

P.S.: injectso isn't android 4.3 compatible in terms of system daemons :)
