### PR TITLE
Missing destination directory for adb push

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cd hijack
 cd jni
 ndk-build
 cd ..
-adb push libs/armeabi/hijack 
+adb push libs/armeabi/hijack /data/local/tmp/
 cd ..
 ```
 


### PR DESCRIPTION
Destination directory for adb push is missing. Probably /data/local/tmp/ is the right directory as it used later on.
